### PR TITLE
fix: allocationToken out of range

### DIFF
--- a/lib/exporter/prometheus/disk.go
+++ b/lib/exporter/prometheus/disk.go
@@ -100,8 +100,13 @@ func (e *promExporter) getDmCacheStatsMetrics() ([]metric, error) {
 	for index, line := range lines {
 		tokens := strings.SplitN(line, " ", 13)
 		cache := e.dmCacheClients[index]
-		allocationRatioStr := strings.TrimSpace(tokens[3])
-		allocationTokens := strings.SplitN(allocationRatioStr, "/", 2)
+		var allocationTokens []string
+		for _, t := range tokens {
+			if strings.Contains(t, "/") {
+				allocationTokens = strings.SplitN(t, "/", 2)
+				break
+			}
+		}
 		attr := fmt.Sprintf("device=%q", cache)
 
 		metrics = appendFloatMetric(metrics, "node_flashcache_cached_blocks", allocationTokens[0], 1, "", "")


### PR DESCRIPTION
Fix the issue of different data being read when executing `dmsetup status --noflush` on different devices, leading to a panic error.

```
panic: runtime error: index out of range [1] with length 1

goroutine 124 [running]:
github.com/pedropombeiro/qnapexporter/lib/exporter/prometheus.(*promExporter).getDmCacheStatsMetrics(0xc000320540)
	/github/workspace/lib/exporter/prometheus/disk.go:108 +0x545
github.com/pedropombeiro/qnapexporter/lib/exporter/prometheus.fetchMetricsWorker(0x0?, 0x0?, 0xd, 0x0?)
	/github/workspace/lib/exporter/prometheus/prometheus.go:166 +0x78
created by github.com/pedropombeiro/qnapexporter/lib/exporter/prometheus.(*promExporter).WriteMetrics
	/github/workspace/lib/exporter/prometheus/prometheus.go:126 +0x1fc
```

I have only tested it on my device, and it works well. Currently, the unhandled logic is for cases where the string divided by '/' does not exist, but this problem probably won't occur. 🤔 

<img width="500" alt="image" src="https://github.com/pedropombeiro/qnapexporter/assets/48400568/f6a67e5c-defa-4b5b-823b-740342c9b820">


Device: TS-464c



close #3