### PR TITLE
add the arm64 architecture build step in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,28 @@ on: # yamllint disable-line rule:truthy
     types: [created]
 
 jobs:
-  release-linux-amd64:
-    name: release linux/amd64
+  release-qnapexporter:
+    name: release qnapexporter
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux]
+        goarch: [amd64, arm64]
     permissions:
       contents: write # for wangyoucao577/go-release-action to upload assets
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+            
       - uses: wangyoucao577/go-release-action@v1.51
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          goos: linux
-          goarch: amd64
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
           build_command: make build PACKAGE_VERSION="$GITHUB_REF_NAME"
           binary_name: bin/qnapexporter
-          asset_name: qnapexporter
+          asset_name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
           overwrite: true


### PR DESCRIPTION
add the arm64 architecture build step in release workflows.
the build package i tested on my QNAP TS-932PX, its works.