### PR TITLE
QPKG package for qnapexporter, built and released via github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:  # yamllint disable-line rule:truthy
       - master
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
 
@@ -31,8 +32,79 @@ jobs:
           make build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: qnapexporter
           path: bin/qnapexporter
+          retention-days: 30
+
+  build-image-qdk:
+    runs-on: ubuntu-latest
+
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image with QDK
+        uses: docker/build-push-action@v6
+        with:
+          file: qpkg/Dockerfile
+          tags: qdk-image:latest
+          outputs: type=docker,dest=/tmp/qdk-image.tar
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdk-image.tar
+          path: /tmp/qdk-image.tar
+
+  build-qpkg:
+    runs-on: ubuntu-latest
+    needs: [build, build-image-qdk]
+
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download qnapexporter artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qnapexporter
+          path: qpkg/shared/
+      
+      - name: Download qdk-image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qdk-image.tar
+          path: /tmp
+
+      - name: Set git sha_short
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Prepare QPKG build
+        run: |
+          sed -i 's/QPKG_VER="0.0.0"/QPKG_VER="${{ steps.vars.outputs.sha_short }}"/g' ./qpkg/qpkg.cfg
+          chmod 755 qpkg/shared/qnapexporter
+          docker load --input /tmp/qdk-image.tar
+
+      - name: Build qpkg for qnapexporter
+        uses: addnab/docker-run-action@v3
+        with:
+          image: qdk-image:latest
+          options: -v ${{ github.workspace }}:/work
+          run: /usr/share/QDK/bin/qbuild --root /work/qpkg/
+
+      - name: Upload qpkg artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: QNAPExporter_${{ steps.vars.outputs.sha_short }}.qpkg
+          path: qpkg/build/QNAPExporter_${{ steps.vars.outputs.sha_short }}.qpkg
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,32 @@ on: # yamllint disable-line rule:truthy
     types: [created]
 
 jobs:
+
+  build-image-qdk:
+    runs-on: ubuntu-latest
+
+    steps: 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build docker image with QDK
+        uses: docker/build-push-action@v6
+        with:
+          file: qpkg/Dockerfile
+          tags: qdk-image:latest
+          outputs: type=docker,dest=/tmp/qdk-image.tar
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: qdk-image.tar
+          path: /tmp/qdk-image.tar
+
   release-qnapexporter:
     name: release qnapexporter
     runs-on: ubuntu-latest
@@ -30,4 +56,63 @@ jobs:
           build_command: make build PACKAGE_VERSION="$GITHUB_REF_NAME"
           binary_name: bin/qnapexporter
           asset_name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          overwrite: true
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: bin/qnapexporter
+          retention-days: 30
+
+  release-qpkg:
+    name: release qpkg
+    runs-on: ubuntu-latest
+    needs: [build-image-qdk, release-qnapexporter]
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [amd64, arm64]
+    permissions:
+      contents: write # for wangyoucao577/go-release-action to upload assets
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download qnapexporter artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: qpkg/shared/
+
+      - name: Download qdk-image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: qdk-image.tar
+          path: /tmp
+      
+      - name: Prepare QPKG build
+        run: |
+          sed -i 's/QPKG_VER="0.0.0"/QPKG_VER="${{ github.ref_name }}"/g' ./qpkg/qpkg.cfg
+          chmod 755 qpkg/shared/qnapexporter
+          docker load --input /tmp/qdk-image.tar
+
+      - name: Build qpkg for qnapexporter
+        uses: addnab/docker-run-action@v3
+        with:
+          image: qdk-image:latest
+          options: -v ${{ github.workspace }}:/work
+          run: /usr/share/QDK/bin/qbuild --root /work/qpkg/
+
+      - name: Release qpkg
+        uses: svenstaro/upload-release-action@2.9.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          file: qpkg/build/QNAPExporter_${{ github.ref_name }}.qpkg
+          asset_name: QNAPExporter_${{ github.ref_name }}_${{ matrix.goarch }}.qpkg
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The data produced by this exporter can be used to create Grafana dashboards such
 
 The Grafana dashboard sources are in the `/dashboards` directory.
 
-## Installation
+## Installation (from binaries)
 
 1. Download the latest qnapexporter executable from the [Releases page](https://github.com/pedropombeiro/qnapexporter/releases)
 1. Run `qnapexporter`
@@ -25,7 +25,14 @@ The Grafana dashboard sources are in the `/dashboards` directory.
     Normally it should be run as a background task. Unfortunately this is not easy on a QNAP NAS.
     See for example [this forum post](https://forum.qnap.com/viewtopic.php?t=44743#p198192) for ideas on how to achieve it.
 
-1. Add target to `scrape_configs` section of `prometheus.ini`
+## Installation (alternative, from qpkg)
+
+1. Download the latest qnapexporter qpkg package from the [Releases page](https://github.com/pedropombeiro/qnapexporter/releases)
+1. Via web ui in QNAP, use manual installation in App Center. Please note that the installation will issue a warning because the QPKG package is not signed. When the binary is installed via QPKG, it will automatically start as background task and can be also stopped/started via App Center.
+
+## Prometheus configuration
+
+Add target to `scrape_configs` section of `prometheus.ini`
 
     ```yaml
     - job_name: 'qnap'

--- a/qpkg/Dockerfile
+++ b/qpkg/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ARG QDK_VER=2.3.14
+
+# install wget
+RUN apt-get update \
+    && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# download QDK
+RUN mkdir qdk \
+    && curl -L -o qdk/v${QDK_VER}.tar.gz https://github.com/qnap-dev/QDK/archive/refs/tags/v${QDK_VER}.tar.gz
+
+# install QDK
+RUN cd qdk \
+    && tar xvfz v${QDK_VER}.tar.gz \
+    && cd QDK-${QDK_VER} \
+    && ./InstallToUbuntu.sh install \
+    && rm -rf /var/lib/apt/lists/*

--- a/qpkg/package_routines
+++ b/qpkg/package_routines
@@ -1,0 +1,140 @@
+######################################################################
+# List of available definitions (it's not necessary to uncomment them)
+######################################################################
+###### Command definitions #####
+#CMD_AWK="/bin/awk"
+#CMD_CAT="/bin/cat"
+#CMD_CHMOD="/bin/chmod"
+#CMD_CHOWN="/bin/chown"
+#CMD_CP="/bin/cp"
+#CMD_CUT="/bin/cut"
+#CMD_DATE="/bin/date"
+#CMD_ECHO="/bin/echo"
+#CMD_EXPR="/usr/bin/expr"
+#CMD_FIND="/usr/bin/find"
+#CMD_GETCFG="/sbin/getcfg"
+#CMD_GREP="/bin/grep"
+#CMD_GZIP="/bin/gzip"
+#CMD_HOSTNAME="/bin/hostname"
+#CMD_LN="/bin/ln"
+#CMD_LOG_TOOL="/sbin/log_tool"
+#CMD_MD5SUM="/bin/md5sum"
+#CMD_MKDIR="/bin/mkdir"
+#CMD_MV="/bin/mv"
+#CMD_RM="/bin/rm"
+#CMD_RMDIR="/bin/rmdir"
+#CMD_SED="/bin/sed"
+#CMD_SETCFG="/sbin/setcfg"
+#CMD_SLEEP="/bin/sleep"
+#CMD_SORT="/usr/bin/sort"
+#CMD_SYNC="/bin/sync"
+#CMD_TAR="/bin/tar"
+#CMD_TOUCH="/bin/touch"
+#CMD_WGET="/usr/bin/wget"
+#CMD_WLOG="/sbin/write_log"
+#CMD_XARGS="/usr/bin/xargs"
+#CMD_7Z="/usr/local/sbin/7z"
+#
+###### System definitions #####
+#SYS_EXTRACT_DIR="$(pwd)"
+#SYS_CONFIG_DIR="/etc/config"
+#SYS_INIT_DIR="/etc/init.d"
+#SYS_STARTUP_DIR="/etc/rcS.d"
+#SYS_SHUTDOWN_DIR="/etc/rcK.d"
+#SYS_RSS_IMG_DIR="/home/httpd/RSS/images"
+#SYS_QPKG_DATA_FILE_GZIP="./data.tar.gz"
+#SYS_QPKG_DATA_FILE_BZIP2="./data.tar.bz2"
+#SYS_QPKG_DATA_FILE_7ZIP="./data.tar.7z"
+#SYS_QPKG_DATA_CONFIG_FILE="./conf.tar.gz"
+#SYS_QPKG_DATA_MD5SUM_FILE="./md5sum"
+#SYS_QPKG_DATA_PACKAGES_FILE="./Packages.gz"
+#SYS_QPKG_CONFIG_FILE="$SYS_CONFIG_DIR/qpkg.conf"
+#SYS_QPKG_CONF_FIELD_QPKGFILE="QPKG_File"
+#SYS_QPKG_CONF_FIELD_NAME="Name"
+#SYS_QPKG_CONF_FIELD_VERSION="Version"
+#SYS_QPKG_CONF_FIELD_ENABLE="Enable"
+#SYS_QPKG_CONF_FIELD_DATE="Date"
+#SYS_QPKG_CONF_FIELD_SHELL="Shell"
+#SYS_QPKG_CONF_FIELD_INSTALL_PATH="Install_Path"
+#SYS_QPKG_CONF_FIELD_CONFIG_PATH="Config_Path"
+#SYS_QPKG_CONF_FIELD_WEBUI="WebUI"
+#SYS_QPKG_CONF_FIELD_WEBPORT="Web_Port"
+#SYS_QPKG_CONF_FIELD_SERVICEPORT="Service_Port"
+#SYS_QPKG_CONF_FIELD_SERVICE_PIDFILE="Pid_File"
+#SYS_QPKG_CONF_FIELD_AUTHOR="Author"
+#SYS_QPKG_CONF_FIELD_RC_NUMBER="RC_Number"
+## The following variables are assigned values at run-time.
+#SYS_HOSTNAME=$($CMD_HOSTNAME)
+## Data file name (one of SYS_QPKG_DATA_FILE_GZIP, SYS_QPKG_DATA_FILE_BZIP2,
+## or SYS_QPKG_DATA_FILE_7ZIP)
+#SYS_QPKG_DATA_FILE=
+## Base location.
+#SYS_QPKG_BASE=""
+## Base location of QPKG installed packages.
+#SYS_QPKG_INSTALL_PATH=""
+## Location of installed software.
+#SYS_QPKG_DIR=""
+## If the QPKG should be enabled or disabled after the installation/upgrade.
+#SYS_QPKG_SERVICE_ENABLED=""
+## Architecture of the device the QPKG is installed on.
+#SYS_CPU_ARCH=""
+## Name and location of system shares
+#SYS_PUBLIC_SHARE=""
+#SYS_PUBLIC_PATH=""
+#SYS_DOWNLOAD_SHARE=""
+#SYS_DOWNLOAD_PATH=""
+#SYS_MULTIMEDIA_SHARE=""
+#SYS_MULTIMEDIA_PATH=""
+#SYS_RECORDINGS_SHARE=""
+#SYS_RECORDINGS_PATH=""
+#SYS_USB_SHARE=""
+#SYS_USB_PATH=""
+#SYS_WEB_SHARE=""
+#SYS_WEB_PATH=""
+## Path to ipkg or opkg package tool if installed.
+#CMD_PKG_TOOL=
+#
+######################################################################
+# All package specific functions shall call 'err_log MSG' if an error
+# is detected that shall terminate the installation.
+######################################################################
+#
+######################################################################
+# Define any package specific operations that shall be performed when
+# the package is removed.
+######################################################################
+#PKG_PRE_REMOVE="{
+#}"
+#
+#PKG_MAIN_REMOVE="{
+#}"
+#
+#PKG_POST_REMOVE="{
+#}"
+#
+######################################################################
+# Define any package specific initialization that shall be performed
+# before the package is installed.
+######################################################################
+#pkg_init(){
+#}
+#
+######################################################################
+# Define any package specific requirement checks that shall be
+# performed before the package is installed.
+######################################################################
+#pkg_check_requirement(){
+#}
+#
+######################################################################
+# Define any package specific operations that shall be performed when
+# the package is installed.
+######################################################################
+#pkg_pre_install(){
+#}
+#
+#pkg_install(){
+#}
+#
+#pkg_post_install(){
+#}

--- a/qpkg/qpkg.cfg
+++ b/qpkg/qpkg.cfg
@@ -1,0 +1,64 @@
+# Name of the packaged application.
+QPKG_NAME="QNAPExporter"
+QPKG_DISPLAYNAME="QNAP Exporter"
+# Version of the packaged application.
+QPKG_VER="0.0.0"
+# Author or maintainer of the package
+QPKG_AUTHOR="https://github.com/pedropombeiro"
+# License for the packaged application
+#QPKG_LICENSE=""
+# One-line description of the packaged application
+QPKG_SUMMARY="qnapexporter is a simple Go program meant to be run in the background on a QNAP NAS in order to export relevant metrics to Prometheus."
+
+# Preferred number in start/stop sequence.
+QPKG_RC_NUM="101"
+# Init-script used to control the start and stop of the installed application.
+QPKG_SERVICE_PROGRAM="qnapexporter.sh"
+QPKG_TIMEOUT="120,60"
+
+# Specifies any packages required for the current package to operate.
+#QPKG_REQUIRE="container-station >= 1.7.1978"
+# Specifies what packages cannot be installed if the current package
+# is to operate properly.
+#QPKG_CONFLICT="Python, OPT/sed"
+# Name of configuration file (multiple definitions are allowed).
+#QPKG_CONFIG="myApp.conf"
+#QPKG_CONFIG="/etc/config/myApp.conf"
+# Port number used by service program.
+QPKG_SERVICE_PORT="9094"
+# Location of file with running service's PID
+#QPKG_SERVICE_PIDFILE=""
+# Relative path to web interface
+QPKG_WEBUI="/"
+# Port number for the web interface.
+QPKG_WEB_PORT="9094"
+# Select volume
+# 1: support installation
+# 2: support migration
+# 3 (1+2): support both installation and migration
+#QPKG_VOLUME_SELECT="0"
+
+# Location of the chroot environment (only TS-x09)
+#QPKG_ROOTFS=""
+# Init-script used to controls the start and stop of the
+# installed application (only TS-x09)
+#QPKG_SERVICE_PROGRAM_CHROOT=""
+
+# Location of icons for the packaged application.
+#QDK_DATA_DIR_ICONS="icons"
+# Location of files specific to arm-x09 packages.
+#QDK_DATA_DIR_X09="arm-x09"
+# Location of files specific to arm-x19 packages.
+#QDK_DATA_DIR_X19="arm-x19"
+# Location of files specific to x86 packages.
+#QDK_DATA_DIR_X86="x86"
+# Location of files specific to x86 (64-bit) packages.
+#QDK_DATA_DIR_X86_64="x86_64"
+# Location of files common to all architectures.
+#QDK_DATA_DIR_SHARED="shared"
+# Location of configuration files.
+#QDK_DATA_DIR_CONFIG="config"
+# Name of local data package.
+#QDK_DATA_FILE=""
+# Name of extra package (multiple definitions are allowed).
+#QDK_EXTRA_FILE=""

--- a/qpkg/shared/qnapexporter.sh
+++ b/qpkg/shared/qnapexporter.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+CONF=/etc/config/qpkg.conf
+QPKG_NAME=QNAPExporter
+QPKG_DIR=$(getcfg $QPKG_NAME Install_Path -f $CONF)
+PID_FILE=/var/run/qnapexporter.pid
+
+# see https://github.com/pedropombeiro/qnapexporter for customization options
+EXTRA_ARGS=""
+
+case "$1" in
+  start)
+    ENABLED=$(getcfg $QPKG_NAME Enable -u -d FALSE -f $CONF)
+    if [ "$ENABLED" != "TRUE" ]; then
+        echo "$QPKG_NAME is disabled."
+        exit 1
+    fi
+
+    if [ -f $PID_FILE ] && kill -0 $(cat $PID_FILE); then
+      echo "$QPKG_NAME is already running."
+      exit 1
+    else
+      $QPKG_DIR/qnapexporter $EXTRA_ARGS &
+      echo $! > $PID_FILE
+    fi
+    ;;
+
+  stop)
+    if [ -f $PID_FILE ]; then
+      PID=$(cat $PID_FILE)
+      if kill -0 $PID; then
+        kill $PID
+        while [ -e /proc/$PID ]; do
+          sleep 1;
+        done
+      fi
+      rm $PID_FILE
+    else
+      echo "$QPKG_NAME is not running."
+      exit 1
+    fi
+    ;;
+
+  restart)
+    $0 stop
+    $0 start
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+esac
+
+exit 0


### PR DESCRIPTION
Hello,
I like what you have done with QNAP Exporter, especially the UPS integration.

Running qnapexporter as background task in QNAP wasn't straightforward, so I thought I'd contribute to the project an automated build of a QPKG package that can be installed via QNAP Web UI in AppCenter; this means that qnapexporter runs as a background task just like any other QNAP application and can be cleanly installed, upgraded or removed.

Briefly, the main changes in this PR are:
- a qpkg/ directory containing the assets required to build the qpkg package (start/stop script, qpkg.conf)
- an expansion of your build and release github actions to include jobs to first build a ubuntu-based docker image with the QDK, and then use that docker image to build qpkg packages for each architecture

I have tested all this on my X86_64 qnap. I don't have a ARM64 qnap to test, although it should work given the only difference is the inclusion of the qnapexporter built for arm64 and everything else is just portable scripts.

Hope this helps!