### PR TITLE
Add support for linux/arm (32-bit) architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm, arm64]
     permissions:
       contents: write # for wangyoucao577/go-release-action to upload assets
     steps:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux]
-        goarch: [amd64, arm64]
+        goarch: [amd64, arm, arm64]
     permissions:
       contents: write # for wangyoucao577/go-release-action to upload assets
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/pedropombeiro/qnapexporter
 
 // +heroku goVersion go1.23
-go 1.23
+go 1.23.0
+
+toolchain go1.23.8
+
 require (
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
This PR adds the `linux/arm` (ARM 32-bit) architecture to the set of packages to be built.
I tested this out on a QNAP TS-431K and it runs without any problems.

Thanks for the great project!

P.S. I had to slightly update the `go.mod` file as well to make the build work.