### PR TITLE
Extend support for linux/arm with v5/v6/v7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Download qnapexporter artifact
         uses: actions/download-artifact@v4
         with:
-          name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
+          name: qnapexporter-${{ github.ref_name }}-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           path: qpkg/shared/
 
       - name: Download qdk-image artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
-        goos: [linux]
-        goarch: [amd64, arm, arm64]
+        include:
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm, goarm: 5 }
+          - { goos: linux, goarch: arm, goarm: 6 }
+          - { goos: linux, goarch: arm, goarm: 7 }
+          - { goos: linux, goarch: arm64 }
     permissions:
       contents: write # for wangyoucao577/go-release-action to upload assets
     steps:
@@ -48,20 +51,21 @@ jobs:
         with:
           fetch-depth: 0
             
-      - uses: wangyoucao577/go-release-action@v1.51
+      - uses: wangyoucao577/go-release-action@v1.53
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
+          goarm: ${{ matrix.goarm }}
           build_command: make build PACKAGE_VERSION="$GITHUB_REF_NAME"
           binary_name: bin/qnapexporter
-          asset_name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          asset_name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           overwrite: true
       
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           path: bin/qnapexporter
           retention-days: 30
 
@@ -71,8 +75,12 @@ jobs:
     needs: [build-image-qdk, release-qnapexporter]
     strategy:
       matrix:
-        goos: [linux]
-        goarch: [amd64, arm, arm64]
+        include:
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm, goarm: 5 }
+          - { goos: linux, goarch: arm, goarm: 6 }
+          - { goos: linux, goarch: arm, goarm: 7 }
+          - { goos: linux, goarch: arm64 }
     permissions:
       contents: write # for wangyoucao577/go-release-action to upload assets
 
@@ -85,7 +93,7 @@ jobs:
       - name: Download qnapexporter artifact
         uses: actions/download-artifact@v4
         with:
-          name: qnapexporter-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           path: qpkg/shared/
 
       - name: Download qdk-image artifact
@@ -108,11 +116,11 @@ jobs:
           run: /usr/share/QDK/bin/qbuild --root /work/qpkg/
 
       - name: Release qpkg
-        uses: svenstaro/upload-release-action@2.9.0
+        uses: svenstaro/upload-release-action@2.11.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
           release_name: ${{ github.ref_name }}
           file: qpkg/build/QNAPExporter_${{ github.ref_name }}.qpkg
-          asset_name: QNAPExporter_${{ github.ref_name }}_${{ matrix.goarch }}.qpkg
+          asset_name: QNAPExporter_${{ github.ref_name }}_${{ matrix.goarch == 'arm' && format('{0}v{1}', matrix.goarch, matrix.goarm) || format('{0}', matrix.goarch) }}.qpkg
           overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,13 @@ jobs:
           goarm: ${{ matrix.goarm }}
           build_command: make build PACKAGE_VERSION="$GITHUB_REF_NAME"
           binary_name: bin/qnapexporter
-          asset_name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
+          asset_name: qnapexporter-${{ github.ref_name }}-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           overwrite: true
       
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: qnapexporter-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
+          name: qnapexporter-${{ github.ref_name }}-${{ matrix.goarch == 'arm' && format('{0}-{1}v{2}', matrix.goos, matrix.goarch, matrix.goarm) || format('{0}-{1}', matrix.goos, matrix.goarch) }}
           path: bin/qnapexporter
           retention-days: 30
 


### PR DESCRIPTION
* Further extend ARM 32-bit support added in https://github.com/pedropombeiro/qnapexporter/pull/13 by adding releases for v5/v6/v7.

* Otherwise, the [qnapexporter-linux-arm.tar.gz](https://github.com/pedropombeiro/qnapexporter/releases/download/v1.0.24/qnapexporter-linux-arm.tar.gz) file from v.1.0.24 was erroring with:

```
[/share/MD0_DATA] # ./qnapexporter
Illegal instruction
```

* Specifically tested with a `TS-219P II`, which is based on a `armv5tel` platform.

```
[~] # cat /etc/issue

Welcome to TS-219P II(192.168.68.84), QNAP Systems, Inc.

[~] # uname -a
Linux nas 3.4.6 #1 Wed Jun 19 14:15:21 CST 2024 armv5tel unknown
[~] #

[/share/MD0_DATA/.qpkg/QNAPExporter] # ./qnapexporter --port :9095
2025/07/19 03:48:48 Listening to HTTP requests at :9095
2025/07/19 03:48:48 Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

---

* Updated some github actions.
* Add version number to release assets.
  * Example:  `qnapexporter-linux-amd64.tar.gz` -> `qnapexporter-v1.0.27-linux-amd64.tar.gz`
* The correct argument for `svenstaro/upload-release-action` seems to be `tag`.